### PR TITLE
fix: serve llm.txt and trigger Pages workflow on gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Jekyll site to Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["gh-pages"]
   workflow_dispatch:
 
 permissions:

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,9 @@ baseurl: ""
 # Build settings
 markdown: kramdown
 
+# Include llm.txt as a static file (Jekyll excludes .txt by default)
+include: [llm.txt]
+
 kramdown:
    parse_block_html: true
    html_to_native: true


### PR DESCRIPTION
## Problem

`llm.txt` was committed on 2026-08-07 (commit 58e8feb) but is not served at https://resume.fr123k.uk/llm.txt (returns 404).

Two root causes:

1. **Workflow trigger mismatch:** `.github/workflows/deploy.yml` triggers on `push: branches: ["main"]`, but the Pages source branch is `gh-pages` (no `main` branch exists). The last successful build was 2026-07-24 — before `llm.txt` was committed — so the live site never included it.

2. **Jekyll excludes .txt files by default:** Jekyll does not copy `.txt` files to `_site` as static files unless they have front matter or are explicitly listed in `include` in `_config.yml`.

## Fix

1. **`.github/workflows/deploy.yml`:** Changed trigger from `branches: ["main"]` to `branches: ["gh-pages"]` so pushes to the actual content branch trigger the Pages build.

2. **`_config.yml`:** Added `include: [llm.txt]` so Jekyll copies `llm.txt` as a static file to `_site`.

## Verification

After merging, the workflow will run automatically and `llm.txt` should be available at https://resume.fr123k.uk/llm.txt with `Content-Type: text/plain`.

```bash
curl -sI https://resume.fr123k.uk/llm.txt  # should return 200
```